### PR TITLE
fix: typing sort in find option

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -194,7 +194,7 @@ const { data, error } = await kontenbase.service('posts').find();
 // -1 = descending
 const { data, error } = await kontenbase
   .service('posts')
-  .find({ sort: { name: 1 } });
+  .find({ sort: [{ name: 1 }] });
 ```
 
 ```js

--- a/js/src/query/lib/types.ts
+++ b/js/src/query/lib/types.ts
@@ -82,7 +82,7 @@ export type FindOption<T> = {
   limit?: number;
   skip?: number;
   where?: Where<T>;
-  sort?: { [P in keyof Partial<T>]: 1 | -1 };
+  sort?: { [P in keyof Partial<T>]: 1 | -1 }[];
   select?: Array<keyof Partial<T>>;
   lookup?: Array<keyof Partial<T>> | '*' | LookupGetId<T> | LookupGetAll<T>;
   or?: Array<Where<T>>;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix typing for sort option on find

## What is the current behavior?

```js sort: { fieldName: 1 } ```

## What is the new behavior?

```js sort: { [fieldName: 1] } ```