### PR TITLE
fix: type of $in & $nin filter

### DIFF
--- a/js/src/query/lib/types.ts
+++ b/js/src/query/lib/types.ts
@@ -50,10 +50,10 @@ type Where<T> =
   | {
       [P in keyof Partial<T> | string]:
         | {
-            ['$in']?: [string | number | boolean];
+            ['$in']?: (string | number | boolean)[];
           }
         | {
-            ['$nin']?: [string | number | boolean];
+            ['$nin']?: (string | number | boolean)[];
           }
         | {
             ['$ne']?: string | number | boolean;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix type of $in & $nin filter

## What is the current behavior?

Can only add 1 value to $in/$nin

## What is the new behavior?

Can add value like an regular array
